### PR TITLE
Amended travis.yml so matplotlib and numpy versions align

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 - "3.3"
 
 env: 
- - DEPS="numpy=1.8.0 scipy matplotlib"
+ - DEPS="numpy=1.8.0 scipy matplotlib=1.3.1”
  - DEPS="numpy=1.9.0 scipy matplotlib"
  - DEPS="numpy scipy matplotlib"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ python:
 - "3.3"
 
 env: 
- - DEPS="numpy=1.8.0 scipy matplotlib=1.3.1”
- - DEPS="numpy=1.9.0 scipy matplotlib"
  - DEPS="numpy scipy matplotlib"
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ def setup_package():
         install_requires=[
             "numpy>1.7",
             "scipy",
-            "matplotlib>1.4",
+            "matplotlib>1.3”,
         ],
           
         extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,9 @@ def setup_package():
         license=open('LICENSE.md').read(),
         tests_require=['nose'],
         install_requires=[
-            "numpy>1.7",
+            "numpy>=1.9.0",
             "scipy",
-            "matplotlib>=1.3.1",
+            "matplotlib>=1.4.3",
         ],
           
         extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ def setup_package():
         install_requires=[
             "numpy>1.7",
             "scipy",
-            "matplotlib>1.3”,
+            "matplotlib>1.3",
         ],
           
         extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ def setup_package():
         install_requires=[
             "numpy>1.7",
             "scipy",
-            "matplotlib>1.3",
+            "matplotlib>=1.3.1",
         ],
           
         extras_require = {


### PR DESCRIPTION
**Don't merge until testing works!**

This should solve the bug from @dhadka's pull request #77, which seemed to fail when installing matplotlib.  I think this is because matplotlib 1.4.3 doesn't work with numpy 1.8 which is what the test suite was installing.  I've enforced installation of matplotlib 1.3.1 when testing with numpy 1.8.
